### PR TITLE
feat: support auto complete npm package and version in admin platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@soku-solid/ui": "^0.0.6",
+    "@soku-solid/ui": "^0.1.1",
     "@solidjs/router": "^0.13.0",
     "axios": "^1.6.7",
     "highlight.js": "^11.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@soku-solid/ui':
-    specifier: ^0.0.6
-    version: 0.0.6(highlight.js@11.9.0)(solid-js@1.8.15)
+    specifier: ^0.1.1
+    version: 0.1.1(highlight.js@11.9.0)(solid-js@1.8.15)
   '@solidjs/router':
     specifier: ^0.13.0
     version: 0.13.0(solid-js@1.8.15)
@@ -886,8 +886,8 @@ packages:
       - typescript
     dev: true
 
-  /@soku-solid/ui@0.0.6(highlight.js@11.9.0)(solid-js@1.8.15):
-    resolution: {integrity: sha512-DjeKSM/GFxJrunqwXOq/aeoptrxJmP7Ku31QN/8GhMkUK2ZC1oJWTLAnLPk6UeGG1F+QulDWuHCjVC59JdZn+A==}
+  /@soku-solid/ui@0.1.1(highlight.js@11.9.0)(solid-js@1.8.15):
+    resolution: {integrity: sha512-157Lyir5yAQ6j9iA/2Fg6XWmJ9Dc+KZMkgEcTxeGBo6PKNfnoR5tVliBYNelFZenAvzO3yTNhJI2MiFv90fymQ==}
     peerDependencies:
       '@soku-solid/utils': latest
       highlight.js: latest

--- a/src/pages/games/components/AddGameForm/api.ts
+++ b/src/pages/games/components/AddGameForm/api.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import { keysIn } from 'lodash-es';
+
+export const ListNpmPackageApi = async (value: string) => {
+  const res = await axios.get(`https://registry.npmjs.org/-/v1/search?text=${value}&size=10`);
+  const data = res.data as any;
+  return data.objects.map((object: any) => object.package.name);
+};
+
+export const ListVersionsApi = async (pkg: string) => {
+  const res = await axios.get(`https://registry.npmjs.org/${pkg}`);
+  const data: any = res.data ?? { versions: {} };
+  return keysIn(data.versions ?? {}).sort().reverse();
+};

--- a/src/pages/games/components/AddGameForm/index.tsx
+++ b/src/pages/games/components/AddGameForm/index.tsx
@@ -1,4 +1,5 @@
 import { Button, Input, NewForm } from '@soku-solid/ui';
+import { createSignal, onCleanup, onMount } from 'solid-js';
 import { MaybePromise } from '@/types';
 import { MarkdownDescription } from '@/pages/games/components/AddGameForm/components';
 
@@ -14,8 +15,46 @@ export const AddGameForm = (props: Props) => {
     props.onSubmit?.(data);
   };
 
+  const [isHolding, setHolding] = createSignal(false);
+  const [offset, setOffset] = createSignal<[number, number]>([0, 0]);
+  const handleMouseDown = (evt: MouseEvent) => {
+    if (evt.button === 0) {
+      const x = evt.offsetX;
+      const y = evt.offsetY;
+      setHolding(true);
+      setOffset([x, y]);
+    }
+  };
+
+  const handleMouseUp = (evt: MouseEvent) => {
+    if (evt.button === 0) {
+      setHolding(false);
+    }
+  };
+
+  let divRef: HTMLDivElement;
+
+  const handleMouseMove = (evt: MouseEvent) => {
+    if (!isHolding()) {
+      return ;
+    }
+    const x = evt.clientX;
+    const y = evt.clientY;
+    const currentOffset = offset();
+    const nx = x - currentOffset[0];
+    const ny = y - currentOffset[1];
+    divRef.style.setProperty('left', `${nx}px`);
+    divRef.style.setProperty('top', `${ny}px`);
+  };
+  onMount(() => {
+    window.addEventListener('mousemove', handleMouseMove);
+  });
+  onCleanup(() => {
+    window.removeEventListener('mousemove', handleMouseMove);
+  });
+
   return (
-    <div class={'absolute left-5 top-10 p10 pt3 bg-#eee rounded-xl text-12px'}>
+    <div ref={el => divRef = el} class={'absolute left-5 top-10 p10 pt3 bg-#eee rounded-xl text-12px cursor-move'} onMouseDown={handleMouseDown} onMouseUp={handleMouseUp}>
       <NewForm form={form}>
         <NewForm.Item
           label={'ID'}


### PR DESCRIPTION
# 需求

- 游戏增加表单支持拖拽
- 引入自动补全组件`AutoComplete`支持自动补全功能
- 添加两个 API ，分别用于获取 npm 包推荐项、对应的 npm 包的版本信息